### PR TITLE
DataManager asynchrones + lien WPF vers API via une classe dédiée #23  #24  #18

### DIFF
--- a/Fantastic3D/Fantastic3D.API/Controllers/UserController.cs
+++ b/Fantastic3D/Fantastic3D.API/Controllers/UserController.cs
@@ -1,118 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Fantastic3D.Persistence.Entities;
-using Fantastic3D.Persistence;
+﻿using Fantastic3D.DataManager;
 using Fantastic3D.Dto;
-using Fantastic3D.DataManager;
+using Fantastic3D.Persistence.Entities;
 
-namespace Fantastic3D.UsersAPI.Controllers
+namespace Fantastic3D.API.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class UserController : ControllerBase
+    public class UserController : GenericController<UserDto, UserEntity>
     {
-        private IDataManager<UserDto, UserEntity> _data;
-
-        public UserController(IDataManager<UserDto, UserEntity> dataManager) 
+        public UserController(IDataManager<UserDto, UserEntity> dataManager) : base(dataManager)
         {
-            _data = dataManager;
-        }
-
-        // GET: api/<UserController>
-        /// <summary>
-        /// Retrieves all the users.
-        /// </summary>
-        [HttpGet]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserDto>))]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public IActionResult Get()
-        {
-            return (_data.GetAll().Any()) ? Ok(_data.GetAll()) : NoContent();
-        }
-
-        // GET api/<UserController>/5
-        /// <summary>
-        /// Retrieves the informations of an user.
-        /// </summary>
-        /// <param name="id" example="5">The user's ID.</param>
-        [HttpGet("{id}")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserDto))]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public IActionResult Get(int id)
-        {
-            try
-            {
-                var retrievedData = _data.Get(id);
-                if (retrievedData == null)
-                    return NotFound(id);
-                return Ok(retrievedData);
-            }
-            catch(InvalidOperationException ioe)
-            {
-                return BadRequest(ioe.Message);
-            }
-        }
-
-        // POST api/<UserController>
-        [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(UserDto))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Post([FromBody] UserDto newUser)
-        {
-            try
-            {
-                _data.Add(newUser);
-                return base.Created(Request.Query.ToString() , newUser);
-            }
-            catch (Exception e)
-            {
-                return BadRequest(newUser);
-            }
-        }
-
-        // PUT api/<UserController>/5
-        /// <summary>
-        /// Changes the informations of an user.
-        /// </summary>
-        /// <param name="id" example="5">The user's ID.</param>
-        /// <param name="value">Full description of an user</param>
-        [HttpPut("{id}")]
-        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(UserDto))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Put(int id, [FromBody] UserDto newUserValues)
-        {
-            try
-            {
-                _data.Update(id, newUserValues);
-                return base.Created(Request.Query.ToString(), newUserValues);
-            }
-            catch (Exception e)
-            {
-                return BadRequest(newUserValues);
-            }
-        }
-
-        // DELETE api/<UserController>/5
-        // GET api/<UserController>/5
-        /// <summary>
-        /// Deletes an user by its id.
-        /// </summary>
-        /// <param name="id" example="5">The user's ID.</param>
-        [HttpDelete("{id}")]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult Delete(int id)
-        {
-            try
-            {
-                _data.Delete(id);
-                return NoContent();
-            }
-            catch
-            {
-                return NotFound(id);
-            }
         }
     }
 }

--- a/Fantastic3D/Fantastic3D.API/Controllers/UserController.cs.bak
+++ b/Fantastic3D/Fantastic3D.API/Controllers/UserController.cs.bak
@@ -1,105 +1,103 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Fantastic3D.Persistence.Entities;
+using Fantastic3D.Persistence;
 using Fantastic3D.Dto;
 using Fantastic3D.DataManager;
-using Fantastic3D.Persistence.Entities;
 
-// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-
-namespace Fantastic3D.API.Controllers
+namespace Fantastic3D.UsersAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class GenericController<TOut, TIn> : ControllerBase
-       where TOut : IManageable, new()
-       where TIn : IManageable, new()
+    public class UserController : ControllerBase
     {
-        private IDataManager<TOut, TIn> _data;
+        private IDataManager<UserDto, UserEntity> _data;
 
-        public GenericController(IDataManager<TOut, TIn> dataManager)
+        public UserController(IDataManager<UserDto, UserEntity> dataManager) 
         {
             _data = dataManager;
         }
 
-        // GET: api/<GenericController>
+        // GET: api/<UserController>
         /// <summary>
         /// Retrieves all the users.
         /// </summary>
         [HttpGet]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserDto>))]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult Get()
         {
-            var data = _data.GetAllAsync().Result;
-            return (data.Any()) ? Ok(data) : NoContent();
+            return (_data.GetAllAsync().Any()) ? Ok(_data.GetAllAsync()) : NoContent();
         }
 
-        // GET api/<GenericController>/5
+        // GET api/<UserController>/5
         /// <summary>
-        /// Retrieves the informations of a database content
+        /// Retrieves the informations of an user.
         /// </summary>
-        /// <param name="id" example="5">The element ID.</param>
+        /// <param name="id" example="5">The user's ID.</param>
         [HttpGet("{id}")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserDto))]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public IActionResult Get(int id)
         {
             try
             {
-                var retrievedData = _data.GetAsync(id).Result;
+                var retrievedData = _data.GetAsync(id);
                 if (retrievedData == null)
                     return NotFound(id);
                 return Ok(retrievedData);
             }
-            catch (InvalidOperationException ioe)
+            catch(InvalidOperationException ioe)
             {
                 return BadRequest(ioe.Message);
             }
         }
 
-        // POST api/<GenericController>
+        // POST api/<UserController>
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(UserDto))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Post([FromBody] TOut newValue)
+        public IActionResult Post([FromBody] UserDto newUser)
         {
             try
             {
-                _data.AddAsync(newValue);
-                return base.Created(Request.Query.ToString(), newValue);
+                _data.Add(newUser);
+                
+                return base.Created(Request.Query.ToString() , newUser);
             }
             catch (Exception e)
             {
-                return BadRequest(newValue);
+                return BadRequest(e.Message.ToString());
             }
         }
 
-        // PUT api/<GenericController>/5
+        // PUT api/<UserController>/5
         /// <summary>
         /// Changes the informations of an user.
         /// </summary>
         /// <param name="id" example="5">The user's ID.</param>
         /// <param name="value">Full description of an user</param>
         [HttpPut("{id}")]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(UserDto))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Put(int id, [FromBody] TOut updatedValue)
+        public IActionResult Put(int id, [FromBody] UserDto newUserValues)
         {
             try
             {
-                _data.UpdateAsync(id, updatedValue);
-                return base.Created(Request.Query.ToString(), updatedValue);
+                _data.UpdateAsync(id, newUserValues);
+                return base.Created(Request.Query.ToString(), newUserValues);
             }
             catch (Exception e)
             {
-                return BadRequest(updatedValue);
+                return BadRequest(newUserValues);
             }
         }
 
-        // DELETE api/<GenericController>/5
-        // GET api/<GenericController>/5
+        // DELETE api/<UserController>/5
+        // GET api/<UserController>/5
         /// <summary>
-        /// Deletes a value by its id.
+        /// Deletes an user by its id.
         /// </summary>
         /// <param name="id" example="5">The user's ID.</param>
         [HttpDelete("{id}")]
@@ -109,7 +107,7 @@ namespace Fantastic3D.API.Controllers
         {
             try
             {
-                _data.DeleteAsync(id);
+                _data.Delete(id);
                 return NoContent();
             }
             catch

--- a/Fantastic3D/Fantastic3D.AppModels/UserModelProfile.cs
+++ b/Fantastic3D/Fantastic3D.AppModels/UserModelProfile.cs
@@ -12,19 +12,19 @@ namespace Fantastic3D.AppModels
     {
         public UserModelProfile()
         {
-            CreateMap<UserDto, User>();
+            CreateMap<UserDto, User>().ReverseMap();
 
-            CreateMap<TagDto, Tag>();
+            CreateMap<TagDto, Tag>().ReverseMap();
 
-            CreateMap<TagTypeDto, TagType>();
+            CreateMap<TagTypeDto, TagType>().ReverseMap();
 
-            CreateMap<AssetDto, Asset>();
+            CreateMap<AssetDto, Asset>().ReverseMap();
 
-            CreateMap<OrderDto, Order>();
+            CreateMap<OrderDto, Order>().ReverseMap();
 
-            CreateMap<PurchaseDto, Purchase>();
+            CreateMap<PurchaseDto, Purchase>().ReverseMap();
 
-            CreateMap<ReviewDto, Review>();
+            CreateMap<ReviewDto, Review>().ReverseMap();
 
 
         }

--- a/Fantastic3D/Fantastic3D.DataManager/IDataManager.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/IDataManager.cs
@@ -9,10 +9,10 @@
         where TTransfered : IManageable, new()
         where TPersistant : IManageable, new()
     {
-        public IEnumerable<TTransfered> GetAll();
-        public TTransfered Get(int id);
-        public void Add(TTransfered transferedObject);
-        public void Update(int id, TTransfered transferedObject);
-        public void Delete(int id);
+        public Task<IEnumerable<TTransfered>> GetAllAsync();
+        public Task<TTransfered> GetAsync(int id);
+        public Task AddAsync(TTransfered transferedObject);
+        public Task UpdateAsync(int id, TTransfered transferedObject);
+        public Task DeleteAsync(int id);
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -60,13 +60,13 @@ namespace Fantastic3D.GUI
 
         }
 
-        public void Delete(int id)
+        public async Task DeleteAsync(int id)
         {
             try
             {
                 var url = "/api/User/" + id;
 
-                HttpResponseMessage response = client.DeleteAsync(url).Result;
+                HttpResponseMessage response = await client.DeleteAsync(url);
                 if (response.IsSuccessStatusCode)
 
                 {
@@ -88,15 +88,15 @@ namespace Fantastic3D.GUI
             }
         }
 
-        public TModel Get(int id)
+
+        public Task<TModel> GetAsync(int id)
         {
-                throw new NotImplementedException();
+            throw new NotImplementedException();
         }
 
-
-        public void Update(int id, TModel transferedObject)
+        public Task UpdateAsync(int id, TModel transferedObject)
         {
-                throw new NotImplementedException();
+            throw new NotImplementedException();
         }
     }
 

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -71,15 +71,16 @@ namespace Fantastic3D.GUI
                 string urlAppend = "/" + id;
 
                 HttpResponseMessage response = await client.DeleteAsync(url + urlAppend);
-                if (response.IsSuccessStatusCode)
-                {
-                    MessageBox.Show("User Deleted");
-                    //return;
-                }
-                else
-                {
-                    MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
-                }
+                // TODO : Gérer autrement le statut du Delete (APIDataManager doit être découplée de WPF)
+                // if (response.IsSuccessStatusCode)
+                // {
+                //     MessageBox.Show("User Deleted");
+                //     //return;
+                //  }
+                // else
+                // {
+                //     MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
+                // }
             }
             catch
                 (Exception ex)

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -30,47 +30,34 @@ namespace Fantastic3D.GUI
         }
         //    // Le chat a dit : 000000000111111111111111111111111111111
 
-        public IEnumerable<TModel> GetAll()
+        public async Task<IEnumerable<TModel>> GetAllAsync()
         {
             try
-            { 
-                HttpResponseMessage response = client.GetAsync(url).Result;
+            {
+                var request = await client.GetFromJsonAsync<IEnumerable<TDto>>(url);
 
-                if (response.IsSuccessStatusCode)
+                if (request == null)
                 {
-                    var result = response.Content.ReadFromJsonAsync<IEnumerable<TDto>>().Result;
-
-                    var mappedValues = _mapper.Map<IEnumerable<TModel>>(result);
-                    return mappedValues;
-
+                    throw new Exception($"Requete null");
                 }
                 else
                 {
-                    return Enumerable.Empty<TModel>();
+                    var mappedValues = _mapper.Map<IEnumerable<TModel>>(request);
+                    return mappedValues;
                 }
             }
             catch (Exception ex)
             {
-                throw new Exception($"L'API n'a pas répondu {ex.Message}", ex);
+                throw new Exception($"{ex.Message}", ex);
             }
         }
 
-        public void Add(TModel transferedObject)
+        public async Task AddAsync(TModel userInfoDto)
         {
-            //client.DefaultRequestHeaders.Accept.Add(
-            //     new MediaTypeWithQualityHeaderValue("application/json"));
-            var response = client.PostAsJsonAsync("api/employee", transferedObject).Result;
-            if (response.IsSuccessStatusCode)
+            
+            var response = await client.PostAsJsonAsync("api/employee", userInfoDto);
+            //return response;
 
-            {
-                MessageBox.Show("Employee Added");
-            }
-
-            else
-
-            {
-                MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
-            }
         }
 
         public void Delete(int id)

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -21,15 +21,16 @@ namespace Fantastic3D.GUI
     {
         HttpClient client = new HttpClient();
 
-        private string url = "https://localhost:7164/api/" + typeof(TModel).Name;
+        private string url = "https://localhost:7164/api/" + typeof(TModel).Name ;
         private IMapper _mapper = ((App)Application.Current).Mapper;
 
         public ApiDataManager()
         {
-            client.BaseAddress = new Uri("https://localhost:7164/");
+            //client.BaseAddress = new Uri("https://localhost:7164/");
         }
-        //    // Le chat a dit : 000000000111111111111111111111111111111
+        
 
+        //Getall
         public async Task<IEnumerable<TModel>> GetAllAsync()
         {
             try
@@ -52,33 +53,32 @@ namespace Fantastic3D.GUI
             }
         }
 
-        public async Task AddAsync(TModel userInfoDto)
+
+        // Add- Post
+        public async Task AddAsync(TModel value)
         {
-            
-            var response = await client.PostAsJsonAsync("api/employee", userInfoDto);
+            var mappedValue = _mapper.Map<TDto>(value);
+            var response = await client.PostAsJsonAsync(url, mappedValue);
             //return response;
 
         }
 
+        // Delete
         public async Task DeleteAsync(int id)
         {
             try
             {
-                var url = "/api/User/" + id;
+                string urlAppend = "/" + id;
 
-                HttpResponseMessage response = await client.DeleteAsync(url);
+                HttpResponseMessage response = await client.DeleteAsync(url + urlAppend);
                 if (response.IsSuccessStatusCode)
-
                 {
                     MessageBox.Show("User Deleted");
                     //return;
                 }
-
                 else
-
                 {
                     MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
-
                 }
             }
             catch
@@ -88,15 +88,50 @@ namespace Fantastic3D.GUI
             }
         }
 
-
-        public Task<TModel> GetAsync(int id)
+        // GetById
+        public async Task<TModel> GetAsync(int id)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var urltotal = url +"/"+ id;
+                var request = await client.GetFromJsonAsync<TDto>(urltotal);
+
+                if (request == null)
+                {
+                    throw new Exception($"Requete null");
+                }
+                else
+                {
+                    var mappedValues = _mapper.Map<TModel>(request);
+                    return mappedValues;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"{ex.Message}", ex);
+            }
         }
 
-        public Task UpdateAsync(int id, TModel transferedObject)
+
+        // Update
+        public async Task UpdateAsync(int id, TModel transferedObject)
         {
-            throw new NotImplementedException();
+            string urlAppend = "/" + id;
+
+            var mappedValues = _mapper.Map<TDto>(transferedObject);
+            
+            var response  = await client.PutAsJsonAsync(url + urlAppend, mappedValues);
+
+           if (response.IsSuccessStatusCode)
+            {
+                MessageBox.Show("User Deleted");
+                //return;
+            }
+           else
+            {
+                MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
+            }
+
         }
     }
 

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml
@@ -10,7 +10,7 @@
     <StackPanel Background="{DynamicResource MaterialDesignBackground}">
         <TextBlock DockPanel.Dock="Top" FontSize="30"  HorizontalAlignment="Center">Gestion des modèles</TextBlock>
 
-        <DataGrid Height="289" SelectedItem="{Binding Path= CurrentUser}" ItemsSource="{Binding Items}"  Width="654" AutoGenerateColumns="True">
+        <DataGrid Height="289" SelectedItem="{Binding Path=CurrentAsset}" ItemsSource="{Binding Items}"  Width="654" AutoGenerateColumns="True">
         </DataGrid>
 
     </StackPanel>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml
@@ -10,8 +10,7 @@
     <StackPanel Background="{DynamicResource MaterialDesignBackground}">
         <TextBlock DockPanel.Dock="Top" FontSize="30"  HorizontalAlignment="Center">Gestion des modèles</TextBlock>
 
-        <DataGrid Height="289" SelectedItem="{Binding Path=CurrentAsset}" ItemsSource="{Binding Items}"  Width="654" AutoGenerateColumns="True">
-        </DataGrid>
+        <DataGrid Height="289" SelectedItem="{Binding Path=CurrentAsset}" ItemsSource="{Binding Items}"  Width="654" AutoGenerateColumns="True" IsReadOnly="True"/>
 
     </StackPanel>
 

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -37,15 +37,16 @@ namespace Fantastic3D.GUI.SectionControls
             LoadAssets();
         }
 
-        private void LoadAssets()
+        private async void LoadAssets()
         {
             try
             {
-                var Assets = _dataSource.GetAll();
+                var Assets = await _dataSource.GetAllAsync();
                 if (Assets != null)
                 {
                     AssetsList.Items = new ObservableCollection<Asset>(Assets);
                 }
+                if()
                 MessageBox.Show($"{Assets.Count()} modèles 3D trouvés.", "Connexion réussie", MessageBoxButton.OK, MessageBoxImage.Information);
 
             }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -45,10 +45,9 @@ namespace Fantastic3D.GUI.SectionControls
                 if (Assets != null)
                 {
                     AssetsList.Items = new ObservableCollection<Asset>(Assets);
+                    MessageBox.Show($"{Assets.Count()} modèles 3D trouvés.", "Connexion réussie", MessageBoxButton.OK, MessageBoxImage.Information);
                 }
-                if()
-                MessageBox.Show($"{Assets.Count()} modèles 3D trouvés.", "Connexion réussie", MessageBoxButton.OK, MessageBoxImage.Information);
-
+                MessageBox.Show($"Aucun modèle 3D trouvé. La base de donnée est peut-être vide ou l'API est innaccessible.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             catch (Exception ex)
             {

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -42,12 +42,16 @@ namespace Fantastic3D.GUI.SectionControls
             try
             {
                 var Assets = await _dataSource.GetAllAsync();
-                if (Assets != null)
+                if (Assets != null && Assets.Count() > 0)
                 {
                     AssetsList.Items = new ObservableCollection<Asset>(Assets);
                     MessageBox.Show($"{Assets.Count()} modèles 3D trouvés.", "Connexion réussie", MessageBoxButton.OK, MessageBoxImage.Information);
                 }
-                MessageBox.Show($"Aucun modèle 3D trouvé. La base de donnée est peut-être vide ou l'API est innaccessible.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
+                else
+                {
+                    MessageBox.Show($"Aucun modèle 3D trouvé. La base de donnée est peut-être vide ou l'API est innaccessible.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
+
+                }
             }
             catch (Exception ex)
             {

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
@@ -33,17 +33,15 @@ namespace Fantastic3D.GUI.SectionControls
             LoadUsers();
         }
 
-        private void LoadUsers()
+        private async void LoadUsers()
         {
             try
             { 
-                var Users = _dataSource.GetAll();
+                var Users =  await _dataSource.GetAllAsync();
                 if (Users != null)
                 {
                     UsersList.Users = new ObservableCollection<User>(Users);
                 }
-
-
             }
             catch (Exception ex)
             {
@@ -56,9 +54,9 @@ namespace Fantastic3D.GUI.SectionControls
             LoadUsers();
         }
 
-        private void Button_AddUser(object sender, RoutedEventArgs e)
+        private async void Button_AddUser(object sender, RoutedEventArgs e)
         {
-            UserDto newDto = new UserDto();
+            User newDto = new UserDto();
             //newDto.Id = 4;
             newDto.FirstName = FirstName.Text;
             newDto.LastName = LastName.Text;
@@ -68,24 +66,11 @@ namespace Fantastic3D.GUI.SectionControls
             //newDto.Role = Role.Text;
             newDto.BillingAddress = BillingAddress.Text;
 
-            HttpClient client = new HttpClient();
+            var maRequeteAll = await _dataSource.AddAsync(newDto);
 
-            client.BaseAddress = new Uri("https://localhost:7164/");
-            client.DefaultRequestHeaders.Accept.Add(
-                 new MediaTypeWithQualityHeaderValue("application/json"));
-            HttpResponseMessage response = client.PostAsJsonAsync("/api/User", newDto).Result;
+            MessageBox.Show("Ajouté avec succès", "ADD", MessageBoxButton.OK, MessageBoxImage.Information);
 
-            if (response.IsSuccessStatusCode)
 
-            {
-                MessageBox.Show("Employee Added");
-            }
-
-            else
-
-            {
-                MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase + response.ToString());
-            }
         }
 
 

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
@@ -18,6 +18,7 @@ namespace Fantastic3D.GUI.SectionControls
     public partial class UserListControl : UserControl
     {
         public UserList UsersList { get; set; } = new UserList();
+        public User UserInForm { get; set; } = new User();
         public IDataManager<User, UserDto> _dataSource = new ApiDataManager<User, UserDto>();
         //private readonly IMapper _mapper = ((App)Application.Current).Mapper;
 
@@ -56,21 +57,21 @@ namespace Fantastic3D.GUI.SectionControls
 
         private async void Button_AddUser(object sender, RoutedEventArgs e)
         {
-            User newDto = new UserDto();
-            //newDto.Id = 4;
-            newDto.FirstName = FirstName.Text;
-            newDto.LastName = LastName.Text;
-            newDto.Email = Email.Text;
-            newDto.Password = "ppppp";
-           // newDto.HashSalt = string.Empty;
-            //newDto.Role = Role.Text;
-            newDto.BillingAddress = BillingAddress.Text;
+            User userToAdd = new User();
+            userToAdd.Username = Username.Text;
+            userToAdd.FirstName = FirstName.Text;
+            userToAdd.LastName = LastName.Text;
+            userToAdd.Email = Email.Text;
+            userToAdd.Password = "";
+            userToAdd.Role = UserRole.Basic;
+            userToAdd.BillingAddress = BillingAddress.Text;
 
-            var maRequeteAll = await _dataSource.AddAsync(newDto);
+            var totalUsers = UsersList.Users.Count;
 
+            await _dataSource.AddAsync(userToAdd);
+            LoadUsers();
             MessageBox.Show("Ajouté avec succès", "ADD", MessageBoxButton.OK, MessageBoxImage.Information);
-
-
+            // todo : verifier que k'ajout a etait fiat
         }
 
 
@@ -79,54 +80,33 @@ namespace Fantastic3D.GUI.SectionControls
         {
             try
             {
-                int id = 2;
-
-                _dataSource.Delete(id);
-                LoadUsers();
+                if (MessageBox.Show($"Voulez-vous vraiment supprimer {UsersList.CurrentUser.Username} ?", 
+                    "Suppression", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                    _dataSource.DeleteAsync(UsersList.CurrentUser.Id);
+                
             }
             catch
             {
 
             }
+            LoadUsers();
         }
 
         private void Button_EditUser(object sender, RoutedEventArgs e)
         {
+            User newUpdat = new User();
+            newUpdat.Id = UsersList.CurrentUser.Id;
+            newUpdat.Username = Username.Text;
+            newUpdat.FirstName = FirstName.Text;
+            newUpdat.LastName = LastName.Text;
+            newUpdat.Email = Email.Text;
+            newUpdat.Password = "";
+            newUpdat.Role = UserRole.Basic;
+            newUpdat.BillingAddress = BillingAddress.Text;
 
-            UserDto newDto = new UserDto();
-            //newDto.Id = 4;
-            newDto.FirstName = FirstName.Text;
-            newDto.LastName = LastName.Text;
-            newDto.Email = Email.Text;
-            newDto.Password = "ppppp";
-            // newDto.HashSalt = string.Empty;
-            //newDto.Role = Role.Text;
-            newDto.BillingAddress = BillingAddress.Text;
-
-            HttpClient client = new HttpClient();
-
-            client.BaseAddress = new Uri("https://localhost:7164/");
-            var id = 2;
-            var url = "/api/User/" + id;
-
-            HttpResponseMessage response = client.PutAsJsonAsync(url, newDto).Result;
-
-            if (response.IsSuccessStatusCode)
-
-            {
-                MessageBox.Show("User Editer");
-                LoadUsers();
-
-                // BindEmployeeList();
-
-            }
-
-            else
-
-            {
-                MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
-
-            }
+            if (MessageBox.Show($"Voulez-vous vraiment Editer {UsersList.CurrentUser.Username} ?",
+                    "Suppression", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                _dataSource.UpdateAsync(UsersList.CurrentUser.Id, newUpdat);
         }
     }
 }

--- a/Fantastic3D/Persistence/Repositories/DbDataManager.cs
+++ b/Fantastic3D/Persistence/Repositories/DbDataManager.cs
@@ -29,37 +29,40 @@ namespace Fantastic3D.Persistence
             _mapper = mapper;
         }
 
-        public TTransfered Get(int id)
+        public async Task<TTransfered> GetAsync(int id)
         {
-            return _mapper.Map<TTransfered>(_dataSet.Single(user => user.Id == id));
+            var result = await _dataSet.SingleAsync(user => user.Id == id);
+            return _mapper.Map<TTransfered>(result);
         }
 
-        public IEnumerable<TTransfered> GetAll()
+        public async Task<IEnumerable<TTransfered>> GetAllAsync()
         {
-            return _dataSet.Select(user => _mapper.Map<TTransfered>(user));
+            return await Task.FromResult(_dataSet.Select(user => _mapper.Map<TTransfered>(user)));
         }
 
-        public void Add(TTransfered objectToAdd)
+        public async Task AddAsync(TTransfered objectToAdd)
         {
             if (objectToAdd == null)
                 throw new ArgumentNullException("Can't add an empty value.");
             // TODO : [DbRepository/ADD] gérer le dédoublonnage lors de l'ajout, ici ou dans le modèle d'entités
             _dataSet.Add(_mapper.Map<TEntity>(objectToAdd));
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
         }
 
-        public void Update(int id, TTransfered transferedObject)
+        public async Task UpdateAsync(int id, TTransfered transferedObject)
         {
-            throw new NotImplementedException();
+            _dataSet.Update(_mapper.Map<TEntity>(transferedObject));
+            await _context.SaveChangesAsync();
         }
 
-        public void Delete(int id)
+        public async Task DeleteAsync(int id)
         {
+            // Todo : [DbRepository/DEL] remplacer Find par une creation d'objet ayant juste l'ID recherché
             var dataToDelete = _dataSet.Find(id);
             if (dataToDelete == null)
                 throw new NullReferenceException("Element to delete wasn't found");
             _dataSet.Remove(dataToDelete);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/Fantastic3D/Persistence/Repositories/DbDataManager.cs
+++ b/Fantastic3D/Persistence/Repositories/DbDataManager.cs
@@ -37,7 +37,8 @@ namespace Fantastic3D.Persistence
 
         public async Task<IEnumerable<TTransfered>> GetAllAsync()
         {
-            return await Task.FromResult(_dataSet.Select(user => _mapper.Map<TTransfered>(user)));
+            var dataList = await _dataSet.ToListAsync();
+            return dataList.Select(item => _mapper.Map<TTransfered>(item));
         }
 
         public async Task AddAsync(TTransfered objectToAdd)


### PR DESCRIPTION
- Classe DataManager consommant l'API (APIDataManager)
- Passage de APIDataManager et DbDataManager en mode asynchrone
- Implémentation dans l'application WPF

État après fusion : 
Crud tout OK en asynchrone, WPF allant puiser dans l'API qui va puiser elle-même dans la BDD
Dans WPF, l'écran "Utilisateurs" permet l'édition complète.