### PR TITLE
Corrections sur les systèmes de Data

### DIFF
--- a/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.html
+++ b/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.html
@@ -1,0 +1,1 @@
+<p><a href="Users">Utilisateurs</a><a href="Configuration">Config</a></p>

--- a/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.spec.ts
+++ b/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MainMenuComponent } from './main-menu.component';
+
+describe('MainMenuComponent', () => {
+  let component: MainMenuComponent;
+  let fixture: ComponentFixture<MainMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MainMenuComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MainMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.ts
+++ b/Angular-Fantastic3D-Website/fantastic-3D-web/src/app/main-menu/main-menu.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-main-menu',
+  templateUrl: './main-menu.component.html',
+  styleUrls: ['./main-menu.component.scss']
+})
+export class MainMenuComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/Fantastic3D/Fantastic3D.API/Controllers/AssetController.cs
+++ b/Fantastic3D/Fantastic3D.API/Controllers/AssetController.cs
@@ -52,7 +52,7 @@ namespace Fantastic3D.API.Controllers
                 _tagsData.AddTagAsync(id, tagId);
                 return Ok($"Tag {tagId} added to asset {id}.");
             }
-            catch (Exception ex)
+            catch (DataRecordException ex)
             {
                 return BadRequest(ex.Message);
             }
@@ -74,7 +74,7 @@ namespace Fantastic3D.API.Controllers
                     return Ok($"Tag {tagId} removed from asset {id}.");
                 return BadRequest("Tag add action did not happen.");
             }
-            catch (Exception ex)
+            catch (DataRecordException ex)
             {
                 return BadRequest(ex.Message);
             }

--- a/Fantastic3D/Fantastic3D.API/Controllers/GenericController.cs
+++ b/Fantastic3D/Fantastic3D.API/Controllers/GenericController.cs
@@ -88,7 +88,7 @@ namespace Fantastic3D.API.Controllers
             try
             {
                 _data.UpdateAsync(id, updatedValue);
-                return base.Created(Request.Query.ToString(), updatedValue);
+                return base.Created(Request.Query.ToString(), _data.GetAsync(id).Result);
             }
             catch (Exception e)
             {

--- a/Fantastic3D/Fantastic3D.API/Controllers/GenericController.cs
+++ b/Fantastic3D/Fantastic3D.API/Controllers/GenericController.cs
@@ -27,9 +27,9 @@ namespace Fantastic3D.API.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public IActionResult Get()
+        public async Task<IActionResult> Get()
         {
-            var data = _data.GetAllAsync().Result;
+            var data = await _data.GetAllAsync();
             return (data.Any()) ? Ok(data) : NoContent();
         }
 
@@ -42,11 +42,11 @@ namespace Fantastic3D.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public IActionResult Get(int id)
+        public async Task<IActionResult> Get(int id)
         {
             try
             {
-                var retrievedData = _data.GetAsync(id).Result;
+                var retrievedData = await _data.GetAsync(id);
                 if (retrievedData == null)
                     return NotFound(id);
                 return Ok(retrievedData);
@@ -61,16 +61,16 @@ namespace Fantastic3D.API.Controllers
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Post([FromBody] TOut newValue)
+        public async Task<IActionResult> Post([FromBody] TOut newValue)
         {
             try
             {
-                _data.AddAsync(newValue);
+                await _data.AddAsync(newValue);
                 return Created(Request.Query.ToString(), newValue);
             }
-            catch (Exception e)
+            catch (DataRecordException dre)
             {
-                return BadRequest(newValue);
+                return BadRequest(dre);
             }
         }
 
@@ -83,16 +83,16 @@ namespace Fantastic3D.API.Controllers
         [HttpPut("{id}")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult Put(int id, [FromBody] TOut updatedValue)
+        public async Task<IActionResult> Put(int id, [FromBody] TOut updatedValue)
         {
             try
             {
-                _data.UpdateAsync(id, updatedValue);
-                return base.Created(Request.Query.ToString(), _data.GetAsync(id).Result);
+                await _data.UpdateAsync(id, updatedValue);
+                return base.Created(Request.Query.ToString(), updatedValue);
             }
-            catch (Exception e)
+            catch (DataRecordException dre)
             {
-                return BadRequest(updatedValue);
+                return BadRequest(updatedValue.ToString() + dre.ToString());
             }
         }
 
@@ -105,11 +105,11 @@ namespace Fantastic3D.API.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult Delete(int id)
+        public async Task<IActionResult> Delete(int id)
         {
             try
             {
-                _data.DeleteAsync(id);
+                await _data.DeleteAsync(id);
                 return NoContent();
             }
             catch

--- a/Fantastic3D/Fantastic3D.API/Controllers/OrderController.cs
+++ b/Fantastic3D/Fantastic3D.API/Controllers/OrderController.cs
@@ -20,9 +20,9 @@ namespace Fantastic3D.API.Controllers
         [HttpGet("{id}/Purchase/")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public IActionResult GetPurchases(int orderId)
+        public async Task<IActionResult> GetPurchases(int orderId)
         {
-            var data = _purchasesData.GetAllAsync().Result;
+            var data = await _purchasesData.GetAllAsync();
             return (data.Any()) ? Ok(data) : NoContent();
         }
 
@@ -35,11 +35,11 @@ namespace Fantastic3D.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public IActionResult GetPurchase(int id, int purchaseId)
+        public async Task<IActionResult> GetPurchase(int id, int purchaseId)
         {
             try
             {
-                var retrievedData = _purchasesData.GetAsync(purchaseId).Result;
+                var retrievedData = await _purchasesData.GetAsync(purchaseId);
                 if (retrievedData == null)
                     return NotFound(purchaseId);
                 return Ok(retrievedData);
@@ -54,17 +54,17 @@ namespace Fantastic3D.API.Controllers
         [HttpPost("{id}/Purchase/")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult PostPurchase(int id, [FromBody] PurchaseDto newValue)
+        public async Task<IActionResult> PostPurchase(int id, [FromBody] PurchaseDto newValue)
         {
             try
             {
                 newValue.OrderId = id;
-                _purchasesData.AddAsync(newValue);
+                await _purchasesData.AddAsync(newValue);
                 return Created(Request.Query.ToString(), newValue);
             }
-            catch (Exception e)
+            catch (DataRecordException e)
             {
-                return BadRequest(newValue);
+                return BadRequest(e.Message);
             }
         }
 
@@ -77,16 +77,16 @@ namespace Fantastic3D.API.Controllers
         [HttpPut("{id}/Purchase/{purchaseId}")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult PutPurchase(int id, int purchaseId, [FromBody] PurchaseDto updatedValue)
+        public async Task<IActionResult> PutPurchase(int id, int purchaseId, [FromBody] PurchaseDto updatedValue)
         {
             try
             {
-                _purchasesData.UpdateAsync(purchaseId, updatedValue);
+                await _purchasesData.UpdateAsync(purchaseId, updatedValue);
                 return base.Created(Request.Query.ToString(), updatedValue);
             }
-            catch (Exception e)
+            catch (DataRecordException e)
             {
-                return BadRequest(updatedValue);
+                return BadRequest(e.Message);
             }
         }
 
@@ -98,11 +98,11 @@ namespace Fantastic3D.API.Controllers
         [HttpDelete("{id}/Purchase/{purchaseId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult DeletePurchase(int id, int purchaseId)
+        public async Task<IActionResult> DeletePurchase(int id, int purchaseId)
         {
             try
             {
-                _purchasesData.DeleteAsync(purchaseId);
+                await _purchasesData.DeleteAsync(purchaseId);
                 return NoContent();
             }
             catch

--- a/Fantastic3D/Fantastic3D.API/Program.cs
+++ b/Fantastic3D/Fantastic3D.API/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
 builder.Services.AddScoped(typeof(IDataManager<,>), typeof(DbDataManager<,>));
+builder.Services.AddScoped(typeof(INestedDataManager<,,>), typeof(DbNestedDataManager<,,>));
 builder.Services.AddScoped<DbContext, LocalDbContext>();
 builder.Services.AddDbContext<LocalDbContext>(option => option.UseSqlServer(builder.Configuration.GetConnectionString("DefaultContext")));
 

--- a/Fantastic3D/Fantastic3D.AppModels/Asset.cs
+++ b/Fantastic3D/Fantastic3D.AppModels/Asset.cs
@@ -11,33 +11,19 @@ namespace Fantastic3D.AppModels
     {
         public enum PublicationStatus { Unpublished, Published, Rejected, Removed }
         public int Id { get; set; }
-        public string Name { get; set; } = String.Empty;
+        public string Name { get; set; }
         public string Description { get; set; }
         public float Price { get; set; }
         public string FilePath { get; set; }
         public string PicturePath { get; set; }
-        //public ICollection<Tag> Tags { get; private set; }
+        public ICollection<Tag> Tags { get; private set; }
         public PublicationStatus Status { get; set; }
-        //public User Creator { get; private set; }
+        public User Creator { get; private set; }
         //public ICollection<Review> Reviews { get; private set; }
 
         public Asset()
         {
 
         }
-
-        //public Asset(int id, string name, string description, float price, string filePath, string picturePath, int creatorId, PublicationStatus status, User creator, ICollection<Review> reviews)
-        //{
-        //    Id = id;
-        //    Name = name;
-        //    Description = description;
-        //    Price = price;
-        //    FilePath = filePath;
-        //    PicturePath = picturePath;
-        //    Tags = new List<Tag>();
-        //    Status = status;
-        //    Creator = creator;
-        //    Reviews = reviews;
-        //}
     }
 }

--- a/Fantastic3D/Fantastic3D.AppModels/DtoToModelProfile.cs
+++ b/Fantastic3D/Fantastic3D.AppModels/DtoToModelProfile.cs
@@ -15,7 +15,9 @@ namespace Fantastic3D.AppModels
             CreateMap<UserDto, User>().ReverseMap();
             CreateMap<TagTypeDto, TagType>().ReverseMap();
             CreateMap<TagDto, Tag>().ReverseMap();
-            CreateMap<AssetDto, Asset>().ReverseMap();
+            CreateMap<AssetDto, Asset>();
+            CreateMap<Asset, AssetDto>()
+                .ForMember(dest => dest.CreatorId, opt => opt.MapFrom(src => src.Creator.Id));
             CreateMap<OrderDto, Order>().ReverseMap();
             CreateMap<PurchaseDto, Purchase>().ReverseMap();
             CreateMap<ReviewDto, Review>().ReverseMap();

--- a/Fantastic3D/Fantastic3D.DataManager/DataRecordException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/DataRecordException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Fantastic3D.DataManager
 {
     /// <summary>
-    /// Represents errors that occur when recording data through a DataManager.
+    /// Represents errors that occurs when recording data through a DataManager.
     /// </summary>
     [Serializable]
     public class DataRecordException : Exception

--- a/Fantastic3D/Fantastic3D.DataManager/DataRecordException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/DataRecordException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Fantastic3D.DataManager
+{
+    /// <summary>
+    /// Represents errors that occur when recording data through a DataManager.
+    /// </summary>
+    [Serializable]
+    public class DataRecordException : Exception
+    {
+        public DataRecordException()
+        {
+        }
+
+        public DataRecordException(string? message) : base(message)
+        {
+        }
+
+        public DataRecordException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected DataRecordException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Fantastic3D/Fantastic3D.DataManager/DataRetrieveException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/DataRetrieveException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Fantastic3D.DataManager
+{
+    /// <summary>
+    /// Represents errors that occur when retrieving data through a DataManager.
+    /// </summary>
+    [Serializable]
+    public class DataRetrieveException : Exception
+    {
+        public DataRetrieveException()
+        {
+        }
+
+        public DataRetrieveException(string? message) : base(message)
+        {
+        }
+
+        public DataRetrieveException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected DataRetrieveException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Fantastic3D/Fantastic3D.DataManager/DataRetrieveException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/DataRetrieveException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Fantastic3D.DataManager
 {
     /// <summary>
-    /// Represents errors that occur when retrieving data through a DataManager.
+    /// Represents errors that occurs when retrieving data through a DataManager.
     /// </summary>
     [Serializable]
     public class DataRetrieveException : Exception

--- a/Fantastic3D/Fantastic3D.DataManager/INestedDataManager.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/INestedDataManager.cs
@@ -1,0 +1,10 @@
+﻿namespace Fantastic3D.DataManager
+{
+
+    public interface INestedDataManager<TTransferedTag, TPersistantAsset, TPersistantTag>
+    {
+        public Task<IEnumerable<TTransferedTag>> GetTagsAsync(int transferedAssetId);
+        public Task<bool> AddTagAsync(int transferedAssetId, int transferedTag);
+        public Task<bool> RemoveTagAsync(int transferedAssetId, int transferedTag);
+    }
+}

--- a/Fantastic3D/Fantastic3D.DataManager/IdMismatchException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/IdMismatchException.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.Serialization;
+
+namespace Fantastic3D.DataManager
+{
+    [Serializable]
+    public class IdMismatchException : Exception
+    {
+        public IdMismatchException()
+        {
+        }
+
+        public IdMismatchException(string? message) : base(message)
+        {
+        }
+
+        public IdMismatchException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected IdMismatchException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Fantastic3D/Fantastic3D.DataManager/IdMismatchException.cs
+++ b/Fantastic3D/Fantastic3D.DataManager/IdMismatchException.cs
@@ -2,6 +2,9 @@
 
 namespace Fantastic3D.DataManager
 {
+    /// <summary>
+    /// Represents errors that occurs when an operation is attempted in a DataManager when providing two distinct IDs for the same Manageable Object.
+    /// </summary>
     [Serializable]
     public class IdMismatchException : Exception
     {

--- a/Fantastic3D/Fantastic3D.Dto/AssetDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/AssetDto.cs
@@ -9,28 +9,24 @@ namespace Fantastic3D.Dto
     public class AssetDto : IManageable
     {
         [DataMember]
-        public static string[] AvailableStatus = new string[] { "Unpublished", "Published", "Rejected", "Removed" };
-        [DataMember]
         public int Id { get; set; }
         [DataMember]
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; }
         [DataMember]
-        public string Description { get; set; } = string.Empty;
+        public string Description { get; set; }
         [DataMember]
         public float Price { get; set; }
         [DataMember]
-        public string FilePath { get; set; } = string.Empty;
+        public string FilePath { get; set; }
         [DataMember]
-        public string PicturePath { get; set; } = string.Empty;
+        public string PicturePath { get; set; }
         [DataMember]
-        public List<int> Tags { get; set; } = new();    // List of Tags Ids
-        [DataMember]
-        public int Creator { get; set; }        // User ID
+        public int CreatorId { get; set; }
         [DataMember]
         /// <summary>
         /// Status ID. Use the AvailableStatus Array to match Status and IDs
         /// </summary>
-        public int Status { get; set; }
+        public string Status { get; set; }
 
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/OrderDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/OrderDto.cs
@@ -13,8 +13,8 @@ namespace Fantastic3D.Dto
         [DataMember]
         public DateTime Date { get; set; }
         [DataMember]
-        public List<Guid> PurchaseList { get; set; } = new();
+        public int PurchasesCount { get; set; }
         [DataMember]
-        public int PurchasingUser { get; set; }
+        public int PurchasingUserId { get; set; }
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/PurchaseDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/PurchaseDto.cs
@@ -17,7 +17,7 @@ namespace Fantastic3D.Dto
         [DataMember]
         public float PurchasePrice { get; set; }
         [DataMember]
-        public Guid Asset { get; set; }        // Asset ID
+        public int AssetId { get; set; }        // Asset ID
 
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/PurchaseDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/PurchaseDto.cs
@@ -17,7 +17,7 @@ namespace Fantastic3D.Dto
         [DataMember]
         public float PurchasePrice { get; set; }
         [DataMember]
-        public int AssetId { get; set; }        // Asset ID
+        public int AssetId { get; set; }
 
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/ReviewDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/ReviewDto.cs
@@ -19,8 +19,8 @@ namespace Fantastic3D.Dto
         [DataMember]
         private bool IsPublished { get; set; }
         [DataMember]
-        public int Asset { get; set; }
+        public int AssetId { get; set; }
         [DataMember]
-        public int Author { get; set; }
+        public int AuthorId { get; set; }
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/TagDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/TagDto.cs
@@ -13,6 +13,6 @@ namespace Fantastic3D.Dto
         [DataMember]
         public string Name { get; set; } = string.Empty;
         [DataMember]
-        public Guid TagType { get; set; }   // Tag Type ID
+        public int TagTypeId { get; set; }   // Tag Type ID
     }
 }

--- a/Fantastic3D/Fantastic3D.Dto/TagTypeDto.cs
+++ b/Fantastic3D/Fantastic3D.Dto/TagTypeDto.cs
@@ -12,7 +12,7 @@ namespace Fantastic3D.Dto
         [DataMember]
         public int Id { get; set; }
         [DataMember]
-        public string Name { get; private set; } = string.Empty;
+        public string Name { get; private set; }
         /// <summary>
         /// Defines if at tag is mandatory (needs to be added at least 1 time to an asset)
         /// </summary>

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -15,20 +15,21 @@ namespace Fantastic3D.GUI
             where TModel : class, IManageable, new()
             where TDto : class, IManageable, new()
     {
-        HttpClient client = new HttpClient();
+        HttpClient _client;
+        string _endpointUrl = typeof(TModel).Name + "/";
         private IMapper _mapper;
 
-        public ApiDataManager(string apiBaseUrl, IMapper mapper)
+        public ApiDataManager(HttpClient client, IMapper mapper)
         {
             _mapper = mapper;
-            client.BaseAddress = new Uri(apiBaseUrl + typeof(TModel).Name);
+            _client = client;
         }
 
         public async Task<IEnumerable<TModel>> GetAllAsync()
         {
             try
             {
-                var retrievedObjects = await client.GetFromJsonAsync<IEnumerable<TDto>>("");
+                var retrievedObjects = await _client.GetFromJsonAsync<IEnumerable<TDto>>(_endpointUrl);
 
                 if (retrievedObjects == null)
                 {
@@ -44,13 +45,14 @@ namespace Fantastic3D.GUI
             {
                 throw new Exception($"{ex.Message}", ex);
             }
+            throw new Exception("GET ALL URL > " + _client.BaseAddress + _endpointUrl);
         }
 
         public async Task<TModel> GetAsync(int id)
         {
             try
             {
-                var retrievedObject = await client.GetFromJsonAsync<TDto>(id.ToString());
+                var retrievedObject = await _client.GetFromJsonAsync<TDto>(_endpointUrl + id);
 
                 if (retrievedObject == null)
                 {
@@ -66,22 +68,25 @@ namespace Fantastic3D.GUI
             {
                 throw new HttpRequestException($"{ex.Message}", ex);
             }
+            throw new Exception("GET URL > " + _client.BaseAddress + _endpointUrl + id);
         }
 
         public async Task AddAsync(TModel addedObject)
         {
             var mappedObject = _mapper.Map<TDto>(addedObject);
-            var httpResponse = await client.PostAsJsonAsync("", mappedObject);
+            var httpResponse = await _client.PostAsJsonAsync(_endpointUrl, mappedObject);
             if (httpResponse == null)
             {
                 throw new DataRecordException($"Aucune réponse de l'API lors de l'ajout d'un nouvel objet. Objet : {addedObject}");
             }
+            throw new Exception("POST URL > " + _client.BaseAddress + _endpointUrl);
         }
 
         public async Task UpdateAsync(int id, TModel transferedObject)
         {
             var mappedValues = _mapper.Map<TDto>(transferedObject);
-            var httpResponse = await client.PutAsJsonAsync(id.ToString(), mappedValues);
+            var httpResponse = await _client.PutAsJsonAsync(_endpointUrl + id, mappedValues);
+            throw new Exception("PUT URL > " + _client.BaseAddress + _endpointUrl + id);
             if (httpResponse == null)
             {
                 throw new DataRecordException($"Aucune réponse de l'API lors de la mise à jour des données. Objet {transferedObject}, mis à jour à l'id {id}");
@@ -92,12 +97,13 @@ namespace Fantastic3D.GUI
         {
             try
             {
-                HttpResponseMessage response = await client.DeleteAsync(id.ToString());
+                HttpResponseMessage response = await _client.DeleteAsync(_endpointUrl + id);
             }
             catch (Exception ex)
             {
                 throw new DataRecordException($"Erreur lors de la suppression de l'objet {id}. Message complet : {ex.Message}", ex);
             }
+            throw new Exception("DELETE URL > " + _client.BaseAddress + _endpointUrl + id);
         }
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -45,7 +45,6 @@ namespace Fantastic3D.GUI
             {
                 throw new Exception($"{ex.Message}", ex);
             }
-            throw new Exception("GET ALL URL > " + _client.BaseAddress + _endpointUrl);
         }
 
         public async Task<TModel> GetAsync(int id)
@@ -68,7 +67,6 @@ namespace Fantastic3D.GUI
             {
                 throw new HttpRequestException($"{ex.Message}", ex);
             }
-            throw new Exception("GET URL > " + _client.BaseAddress + _endpointUrl + id);
         }
 
         public async Task AddAsync(TModel addedObject)
@@ -79,14 +77,12 @@ namespace Fantastic3D.GUI
             {
                 throw new DataRecordException($"Aucune réponse de l'API lors de l'ajout d'un nouvel objet. Objet : {addedObject}");
             }
-            throw new Exception("POST URL > " + _client.BaseAddress + _endpointUrl);
         }
 
         public async Task UpdateAsync(int id, TModel transferedObject)
         {
             var mappedValues = _mapper.Map<TDto>(transferedObject);
             var httpResponse = await _client.PutAsJsonAsync(_endpointUrl + id, mappedValues);
-            throw new Exception("PUT URL > " + _client.BaseAddress + _endpointUrl + id);
             if (httpResponse == null)
             {
                 throw new DataRecordException($"Aucune réponse de l'API lors de la mise à jour des données. Objet {transferedObject}, mis à jour à l'id {id}");
@@ -103,7 +99,6 @@ namespace Fantastic3D.GUI
             {
                 throw new DataRecordException($"Erreur lors de la suppression de l'objet {id}. Message complet : {ex.Message}", ex);
             }
-            throw new Exception("DELETE URL > " + _client.BaseAddress + _endpointUrl + id);
         }
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/ApiDataManager.cs
@@ -49,10 +49,18 @@ namespace Fantastic3D.GUI
 
         public async Task<TModel> GetAsync(int id)
         {
+            var mappedValue = _mapper.Map<TDto>(value);
+            var response = await client.PostAsJsonAsync(url, mappedValue);
+            //return response;
+
+        }
+
+        // Delete
+        public async Task DeleteAsync(int id)
+        {
             try
             {
                 var retrievedObject = await client.GetFromJsonAsync<TDto>(id.ToString());
-
                 if (retrievedObject == null)
                 {
                     throw new DataRetrieveException("Aucune donnée n'a été récupérée.");
@@ -62,6 +70,7 @@ namespace Fantastic3D.GUI
                     var mappedObjects = _mapper.Map<TModel>(retrievedObject);
                     return mappedObjects;
                 }
+                // TODO : Gérer autrement le statut du Delete (APIDataManager doit être découplée de WPF)
             }
             catch (Exception ex)
             {
@@ -82,18 +91,18 @@ namespace Fantastic3D.GUI
                 HttpResponseMessage response = await client.DeleteAsync(id.ToString());
             }
             catch (Exception ex)
-            {
                 throw new DataRecordException($"{ex.Message}", ex);
+                throw new Exception($"{ex.Message}", ex);
             }
         }
 
         public async Task UpdateAsync(int id, TModel transferedObject)
-        {
-            var mappedValues = _mapper.Map<TDto>(transferedObject);
+
             var httpResponse = await client.PutAsJsonAsync(id.ToString(), mappedValues);
             if (httpResponse == null)
-            {
+           else
                 throw new DataRecordException($"Aucune réponse de l'API lors de la mise à jour des données. Objet {transferedObject}, mis à jour à l'id {id}");
+                MessageBox.Show("Error Code" + response.StatusCode + " : Message - " + response.ReasonPhrase);
             }
         }
     }

--- a/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
@@ -15,7 +15,7 @@ namespace Fantastic3D.GUI
     /// </summary>
     public partial class App : Application
     {
-        private const string SERVER_URL = "";
+        public string ApiBaseUrl = "https://localhost:7164/api/";
         public IMapper Mapper { get; }
         public App()
         {

--- a/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
@@ -19,7 +19,6 @@ namespace Fantastic3D.GUI
         public IMapper Mapper { get; }
         public App()
         {
-            // Ajouter l'automapper ici (MapperConfig AddMaps)
             var configuration = new MapperConfiguration(cfg => cfg.AddMaps(typeof(DtoToModelProfile)));
             Mapper = new Mapper(configuration);
         }

--- a/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -15,10 +16,12 @@ namespace Fantastic3D.GUI
     /// </summary>
     public partial class App : Application
     {
-        public string ApiBaseUrl = "https://localhost:7164/api/";
+        public HttpClient Client;
         public IMapper Mapper { get; }
         public App()
         {
+            Client = new HttpClient();
+            Client.BaseAddress = new Uri("https://localhost:7164/api/");
             var configuration = new MapperConfiguration(cfg => cfg.AddMaps(typeof(DtoToModelProfile)));
             Mapper = new Mapper(configuration);
         }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -26,7 +26,8 @@ namespace Fantastic3D.GUI.SectionControls
     {
         public ObservableList<Asset> AssetsList { get; set; } = new ObservableList<Asset>();
         //public Asset SelectedAsset { get; set; }
-        public IDataManager<Asset, AssetDto> _dataSource = new ApiDataManager<Asset, AssetDto>();
+        public IDataManager<Asset, AssetDto> _dataSource =
+            new ApiDataManager<Asset, AssetDto>(((App)Application.Current).ApiBaseUrl, ((App)Application.Current).Mapper);
 
         bool messageBoxHasBeenShown = false;
         public ModelListControl()

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -27,7 +27,7 @@ namespace Fantastic3D.GUI.SectionControls
         public ObservableList<Asset> AssetsList { get; set; } = new ObservableList<Asset>();
         //public Asset SelectedAsset { get; set; }
         public IDataManager<Asset, AssetDto> _dataSource =
-            new ApiDataManager<Asset, AssetDto>(((App)Application.Current).ApiBaseUrl, ((App)Application.Current).Mapper);
+            new ApiDataManager<Asset, AssetDto>(((App)Application.Current).Client, ((App)Application.Current).Mapper);
 
         bool messageBoxHasBeenShown = false;
         public ModelListControl()

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
@@ -51,7 +51,8 @@ namespace Fantastic3D.GUI.SectionControls
             }
         }
 
-        public IDataManager<Asset, AssetDto> _assetsSource = new ApiDataManager<Asset, AssetDto>();
+        public IDataManager<Asset, AssetDto> _assetsSource =
+            new ApiDataManager<Asset, AssetDto>(((App) Application.Current).ApiBaseUrl, ((App) Application.Current).Mapper);
         public ModelViewerControl()
         {
             InitializeComponent();

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
@@ -52,7 +52,7 @@ namespace Fantastic3D.GUI.SectionControls
         }
 
         public IDataManager<Asset, AssetDto> _assetsSource =
-            new ApiDataManager<Asset, AssetDto>(((App) Application.Current).ApiBaseUrl, ((App) Application.Current).Mapper);
+            new ApiDataManager<Asset, AssetDto>(((App) Application.Current).Client, ((App) Application.Current).Mapper);
         public ModelViewerControl()
         {
             InitializeComponent();

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
@@ -19,8 +19,8 @@ namespace Fantastic3D.GUI.SectionControls
     {
         public UserList UsersList { get; set; } = new UserList();
         public User UserInForm { get; set; } = new User();
-        public IDataManager<User, UserDto> _dataSource = new ApiDataManager<User, UserDto>();
-        //private readonly IMapper _mapper = ((App)Application.Current).Mapper;
+        public IDataManager<User, UserDto> _dataSource = 
+            new ApiDataManager<User, UserDto>(((App)Application.Current).ApiBaseUrl, ((App)Application.Current).Mapper);
 
         public UserListControl()
         {

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
@@ -20,7 +20,7 @@ namespace Fantastic3D.GUI.SectionControls
         public UserList UsersList { get; set; } = new UserList();
         public User UserInForm { get; set; } = new User();
         public IDataManager<User, UserDto> _dataSource = 
-            new ApiDataManager<User, UserDto>(((App)Application.Current).ApiBaseUrl, ((App)Application.Current).Mapper);
+            new ApiDataManager<User, UserDto>(((App)Application.Current).Client, ((App)Application.Current).Mapper);
 
         public UserListControl()
         {

--- a/Fantastic3D/Persistence/Entities/AssetEntity.cs
+++ b/Fantastic3D/Persistence/Entities/AssetEntity.cs
@@ -19,13 +19,21 @@ namespace Fantastic3D.Persistence.Entities
         public float Price { get; set; }
         public string FilePath { get; set; }
         public string PicturePath { get; set; }
-        // allows the relationnal table to be created between
-        public virtual ICollection<TagEntity> Tags { get; private set; }
+        public List<TagEntity> Tags { get; set; }
+        //private List<TagEntity> _tags;
+        //public List<TagEntity> Tags {
+        //    get { return _tags == null ? new List<TagEntity>() : _tags; }
+        //    set
+        //    {
+        //        if(_tags == null)
+        //        {
+        //            _tags = new List<TagEntity>();
+        //        }
+        //        _tags.AddRange(value);
+        //    }
+        //}
         public int CreatorId { get; set; }
-
-
         public PublicationStatus Status { get; set; }
-
         public virtual UserEntity Creator { get; private set; }
         public virtual ICollection<ReviewEntity> Reviews { get; private set; }
 
@@ -33,14 +41,14 @@ namespace Fantastic3D.Persistence.Entities
         {
             this.Reviews = new HashSet<ReviewEntity>();
         }
-        public AssetEntity(string name, string description, float price, string filePath, string picturePath, int creatorId, PublicationStatus status)
+        public AssetEntity(string name, string description, float price, string filePath, string picturePath, List<TagEntity> tags, int creatorId, PublicationStatus status)
         {
             Name = name;
             Description = description;
             Price = price;
             FilePath = filePath;
             PicturePath = picturePath;
-            Tags = new List<TagEntity>();
+            Tags = tags;
             CreatorId = creatorId;
             Status = status;
         }
@@ -49,7 +57,7 @@ namespace Fantastic3D.Persistence.Entities
         /// Constructor for an Asset, setting it with a NewGuid and with an Unpublished status.
         /// </summary>
         public AssetEntity(string name, string description, float price, string filePath, string picturePath, int creator)
-            : this(name, description, price, filePath, picturePath, creator, PublicationStatus.Unpublished) { }
+            : this(name, description, price, filePath, picturePath, new List<TagEntity>(), creator, PublicationStatus.Unpublished) { }
 
         public override string ToString()
         {

--- a/Fantastic3D/Persistence/Entities/OrderEntity.cs
+++ b/Fantastic3D/Persistence/Entities/OrderEntity.cs
@@ -14,10 +14,9 @@ namespace Fantastic3D.Persistence.Entities
         [Key]
         public int Id { get; set; }
         public DateTime Date { get; set; }
-
         public int PurchasingUserId { get; set; }
         public virtual UserEntity PurchasingUser { get; private set; }
-        public virtual ICollection<PurchaseEntity> PurchaseList { get; private set; }
+        public virtual ICollection<PurchaseEntity> Purchases { get; private set; }
 
         public OrderEntity() {}
 

--- a/Fantastic3D/Persistence/Repositories/DbDataManager.cs
+++ b/Fantastic3D/Persistence/Repositories/DbDataManager.cs
@@ -45,7 +45,8 @@ namespace Fantastic3D.Persistence
         public async Task AddAsync(TTransfered objectToAdd)
         {
             if (objectToAdd == null)
-                throw new ArgumentNullException("Can't add an empty value.");
+
+                throw new DataRecordException("Can't add an empty value.");
             // TODO : [DbRepository/ADD] gérer le dédoublonnage lors de l'ajout, ici ou dans le modèle d'entités
             _dataSet.Add(_mapper.Map<TEntity>(objectToAdd));
             await _context.SaveChangesAsync();
@@ -56,7 +57,7 @@ namespace Fantastic3D.Persistence
             var objectToUpdate = _mapper.Map<TEntity>(transferedObject);
 
             if (objectToUpdate == null)
-                throw new ArgumentException("Could not convert object.");
+                throw new DataRecordException("Could not convert object.");
             if (objectToUpdate.Id == 0)
                 objectToUpdate.Id = id;
             if (objectToUpdate.Id != id)
@@ -74,7 +75,11 @@ namespace Fantastic3D.Persistence
             { 
                 _dataSet.Update(objectToUpdate);
             }
-            await _context.SaveChangesAsync();
+            var affectedRows = await _context.SaveChangesAsync();
+            if(affectedRows != 1)
+            {
+                throw new DataRecordException("More than one row was affected by this update.");
+            }
         }
 
         public async Task DeleteAsync(int id)
@@ -82,7 +87,7 @@ namespace Fantastic3D.Persistence
             // Todo : [DbRepository/DEL] remplacer Find par une creation d'objet ayant juste l'ID recherché
             var dataToDelete = _dataSet.Find(id);
             if (dataToDelete == null)
-                throw new NullReferenceException("Element to delete wasn't found");
+                throw new DataRecordException("Element to delete wasn't found");
             _dataSet.Remove(dataToDelete);
             await _context.SaveChangesAsync();
         }

--- a/Fantastic3D/Persistence/Repositories/DbNestedDataManager.cs
+++ b/Fantastic3D/Persistence/Repositories/DbNestedDataManager.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Fantastic3D.DataManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Fantastic3D.Dto;
+using Fantastic3D.Persistence.Entities;
+
+namespace Fantastic3D.Persistence
+{
+    public class DbNestedDataManager<TTransferedTag, TPersistantAsset, TPersistantTag>
+        : INestedDataManager<TTransferedTag, TPersistantAsset, TPersistantTag>
+        where TTransferedTag : TagDto, new()
+        where TPersistantAsset : AssetEntity, new()
+        where TPersistantTag : TagEntity, new()
+    {
+        LocalDbContext _context;
+        private IMapper _mapper;
+        private DbSet<TPersistantAsset> _assetDataSet;
+        private DbSet<TPersistantTag> _tagsDataSet;
+
+        public DbNestedDataManager(LocalDbContext context, IMapper mapper)
+        {
+            _context = context;
+            _assetDataSet = context.Set<TPersistantAsset>();
+            _tagsDataSet = context.Set<TPersistantTag>();
+            _mapper = mapper;
+        }
+
+        public async Task<bool> AddTagAsync(int transferedAssetId, int transferedTagId)
+        {
+            try
+            { 
+                var tagToAdd = await _tagsDataSet.SingleAsync(tag => tag.Id == transferedTagId);
+                var assetToUpdate = await _assetDataSet.SingleAsync(asset => asset.Id == transferedAssetId);
+                if(assetToUpdate.Tags == null)
+                    assetToUpdate.Tags = new List<TagEntity>();
+                assetToUpdate.Tags.Add(tagToAdd);
+                await _context.SaveChangesAsync();
+            }
+            catch (InvalidOperationException ioe)
+            {
+                return false;
+                throw new InvalidOperationException("Tag or Asset was not found. ", ioe);
+            }
+            catch (ArgumentNullException ane)
+            {
+                return false;
+                throw new ArgumentNullException("Id or DataSource is null. ", ane);
+            }
+            catch (Exception ex)
+            {
+                return false;
+                throw new Exception("Exception encoutered: ", ex);
+            }
+            return true;
+        }
+
+        public async Task<bool> RemoveTagAsync(int transferedAssetId, int transferedTag)
+        {
+            try
+            {
+                var tagToRemove = await _tagsDataSet.SingleAsync(tag => tag.Id == transferedTag);
+                var assetToUpdate = await _assetDataSet.SingleAsync(asset => asset.Id == transferedAssetId);
+
+                if (assetToUpdate.Tags != null)
+                {
+                    assetToUpdate.Tags.Remove(tagToRemove);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            catch (InvalidOperationException ioe)
+            {
+                return false;
+                throw new InvalidOperationException("Tag or asset was not found. ", ioe);
+            }
+            catch (ArgumentNullException ane)
+            {
+                return false;
+                throw new InvalidOperationException("Id or DataSource is null. ", ane);
+            }
+            catch (Exception ex)
+            {
+                return false;
+                throw new Exception("Unexpected Exception: ", ex);
+            }
+            return true;
+        }
+
+        public async Task<IEnumerable<TTransferedTag>> GetTagsAsync(int transferedAssetId)
+        {
+            try
+            {
+                var assetToRead = await _assetDataSet.SingleAsync(asset => asset.Id == transferedAssetId);
+                var tags = assetToRead.Tags;
+                if(tags == null)
+                    return Enumerable.Empty<TTransferedTag>();
+                //return tags.Select(tag => _mapper.Map<TTransferedTag>(tag));
+                return _mapper.Map<IEnumerable<TTransferedTag>>(tags);
+            }
+            catch (InvalidOperationException ioe)
+            {
+                throw new InvalidOperationException("Asset was not found. ", ioe);
+            }
+            catch (ArgumentNullException ane)
+            {
+                throw new InvalidOperationException("Id or DataSource is null. ", ane);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Unexpected Exception: ", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Cette branche corrige plusieurs choses :
- Des corrections sur les DTO, Entités et Models pour rendre leur fonctionnement plus logique et éviter de passer des listes en DTO (on reste à 1 niveau).
- Le HttpClient est instancié 1 fois au niveau de l'appli WPF, puis injecté à la construction des APIDataManager, ce qui est plus propre.
Voir cet article pour comprendre pourquoi : https://www.codeproject.com/Articles/5272469/HttpClient-Single-Instance-or-Multiple
- Pour les DataManager, il y a des exceptions dédiées, ce sont ces exceptions qu'on fait remonter désormais (mieux adaptée que l'Exception générique).
- J'ai un peu remanié APIDataManager, les erreurs sont gérées via ces Exceptions, plus de message d'erreur. Ainsi, APIDataManager est complètement découplé de l'App WPF (et prêt à accueillir des jeux de tests unitaires).
- Contrôleurs de l'API rendus asynchrones (Dans GenericController, etc.) (il y avait des problèmes avec la connexion à la base de donnée (asynchrone) vs les contrôleurs qu'on avait rendu synchrone, il pouvait y avoir de la concurrence qui faisait planter les requêtes.

Tout marche côté API, mais il y a des problèmes à résoudre côté mapper et Base de données. Donc tu peux avancer sur l'appli WPF en mode "lecture de données", mais ne soit pas surpris si la sauvegarde (Add, Update, Delete) sont H.S. pour l'instant.
 
**Attention @Sylvain125  :** 
Pour le rendre compatible avec ta codebase actuelle, il te faudra déclarer ton _dataSource de cette manière dans **UserListControl.xaml.cs** :
```csharp
        public IDataManager<User, UserDto> _dataSource = 
            new ApiDataManager<User, UserDto>(((App)Application.Current).Client, ((App)Application.Current).Mapper);
```

Dans le futur, je pense qu'on aura intérêt à faire un repository unique pour l'appli et à référencer celui-ci, ça nous évitera de passer partout des références au client et au mapper (j'ai créé l'issue #35 dans cette idée).