### PR TITLE
App WPF : Liens logiques par ID entre les écrans, via ID

### DIFF
--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableById.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableById.cs
@@ -9,7 +9,7 @@ namespace Fantastic3D.GUI.SectionControls
     /// <summary>
     /// Interface for views where the contents can be loaded through a simple id.
     /// </summary>
-    internal interface IContentLoadableById
+    public interface IContentLoadableById
     {
         public void LoadContentById(int id);
     }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableById.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableById.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantastic3D.GUI.SectionControls
+{
+    /// <summary>
+    /// Interface for views where the contents can be loaded through a simple id.
+    /// </summary>
+    internal interface IContentLoadableById
+    {
+        public void LoadContentById(int id);
+    }
+}

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableWithModel.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/IContentLoadableWithModel.cs
@@ -1,0 +1,17 @@
+﻿using Fantastic3D.DataManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantastic3D.GUI.SectionControls
+{
+    /// <summary>
+    /// Describes a view containing a single IManageable Model
+    /// </summary>
+    public interface IContentLoadableWithModel
+    {
+        public void LoadContentWithModel(IManageable modelInstance);
+    }
+}

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelListControl.xaml.cs
@@ -73,8 +73,9 @@ namespace Fantastic3D.GUI.SectionControls
 
         private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            ((MainWindow)Application.Current.MainWindow).Navigator.NavigateTo(typeof(ModelViewerControl));
-            ((ModelViewerControl)((MainWindow)Application.Current.MainWindow).Navigator.CurrentViewControl.Content).CurrentAsset = (Asset)AssetDataGrid.CurrentItem;
+
+            ((MainWindow)Application.Current.MainWindow)
+                .Navigator.NavigateTo(typeof(ModelViewerControl), (Asset)AssetDataGrid.CurrentItem);
         }
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ModelViewerControl.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Fantastic3D.AppModels;
 using Fantastic3D.DataManager;
 using Fantastic3D.Dto;
+using Fantastic3D.GUI.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,7 +22,7 @@ namespace Fantastic3D.GUI.SectionControls
     /// <summary>
     /// Logique d'interaction pour ModelViewerControl.xaml
     /// </summary>
-    public partial class ModelViewerControl : UserControl
+    public partial class ModelViewerControl : UserControl, IContentLoadableWithModel, IContentLoadableById
     {
         public List<Asset> ModelsToValidate { get; set; } = new();
 
@@ -32,7 +33,7 @@ namespace Fantastic3D.GUI.SectionControls
 
         public List<string> LicencesList = new List<string>()
         {
-            "Usage commercial", "Usage personnel", "Libre de droit", "MIT"
+            "Usage commercial", "Usage personnel", "Libre de droit"
         };
         public List<string> FormatsList = new List<string>()
         {
@@ -47,6 +48,7 @@ namespace Fantastic3D.GUI.SectionControls
                 if (currentAsset != value)
                 {
                     SetValue(CurrentAssetProperty, value);
+                    OnContentLoaded();
                 }
             }
         }
@@ -59,6 +61,38 @@ namespace Fantastic3D.GUI.SectionControls
             NextModelsList.ItemsSource = ModelsToValidate;
         }
 
+        /// <summary>
+        /// Mise à jour de la vue selon la données chargée
+        /// </summary>
+        private void OnContentLoaded()
+        {
+            PublishButton.IsEnabled = (CurrentAsset.Status == Asset.PublicationStatus.Unpublished);
+            RejectButton.IsEnabled = (CurrentAsset.Status == Asset.PublicationStatus.Unpublished);
+        }
+
+
+        public void LoadContentWithModel(IManageable modelInstance)
+        {
+            if(modelInstance is Asset asset)
+                CurrentAsset = asset;
+            else
+                throw new NavigationException("Expected " + typeof(Asset).Name + " type. Type sent was: " + modelInstance.GetType().Name);
+        }
+
+        public async void LoadContentById(int id)
+        {
+            try
+            {
+                CurrentAsset = await _assetsSource.GetAsync(id);
+            }
+            catch (DataRetrieveException ex)
+            {
+                MessageBox.Show(ex.Message, "Modèle 3D non trouvé", MessageBoxButton.OK, MessageBoxImage.Error);
+                CurrentAsset = new();
+            }
+        }
+
+
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             MessageBox.Show("Faulty endpoints. Tags can't be edited.", "Invalid operation", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -66,25 +100,32 @@ namespace Fantastic3D.GUI.SectionControls
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
+            SaveButton.IsEnabled = false;
             _assetsSource.UpdateAsync(CurrentAsset.Id, CurrentAsset);
         }
 
         private void PublishButton_Click(object sender, RoutedEventArgs e)
         {
+            PublishButton.IsEnabled = false;
+            RejectButton.IsEnabled = false;
             CurrentAsset.Status = Asset.PublicationStatus.Published;
             _assetsSource.UpdateAsync(CurrentAsset.Id, CurrentAsset);
         }
 
         private void RejectButton_Click(object sender, RoutedEventArgs e)
         {
+            SaveButton.IsEnabled = false;
+            PublishButton.IsEnabled = false;
+            RejectButton.IsEnabled = false;
             CurrentAsset.Status = Asset.PublicationStatus.Rejected;
             _assetsSource.UpdateAsync(CurrentAsset.Id, CurrentAsset);
         }
 
         private void CheckUserButton_Click(object sender, RoutedEventArgs e)
         {
-            ((MainWindow)Application.Current.MainWindow).Navigator.NavigateTo(typeof(UserViewControl));
-            // TODO : Passer un ID à UserViewControl pour afficher l'utilisateur par ID (CurrentAsset.CreatorId)
+            ((MainWindow)Application.Current.MainWindow)
+                .Navigator.NavigateTo(typeof(UserViewControl), CurrentAsset.CreatorId);
         }
+
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderListControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderListControl.xaml
@@ -13,18 +13,18 @@
         <StackPanel >
             <TextBlock DockPanel.Dock="Top" FontSize="30"  HorizontalAlignment="Center">Gestion des commandes</TextBlock>
             <DatePicker
-                  Width="140" 
-                  materialDesign:HintAssist.Hint="Pick Date"
+                  Width="180" 
+                  materialDesign:HintAssist.Hint="Filtrer par date..."
                   Style="{StaticResource MaterialDesignFilledDatePicker}"
                   materialDesign:TextFieldAssist.HasClearButton="True" />
-            <DataGrid  x:Name="OrderDataGrid" SelectedItem="{Binding Path=CurrentOrder}" ItemsSource="{Binding Orders}"  Margin="10" Height="245" AutoGenerateColumns="False" MouseDoubleClick="DataGrid_MouseDoubleClick"  IsReadOnly="True">
+            <DataGrid  x:Name="OrderDataGrid" SelectedItem="{Binding Path=CurrentOrder}" ItemsSource="{Binding Orders}"  Margin="10" Height="245" AutoGenerateColumns="False" MouseDoubleClick="DataGrid_MouseDoubleClick"  IsReadOnly="True" Cursor="IBeam">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Id" Binding="{Binding Id}"/>
-                    <DataGridTextColumn Header="Date" Binding="{Binding Date,  StringFormat={}{0:MM/dd/yyyy}}"/>
-                    <DataGridTextColumn Header="PurchasingUserName" Binding="{Binding PurchasingUserName}"/>
+                    <DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat=d}"/>
+                    <DataGridTextColumn Header="Acheteur" Binding="{Binding PurchasingUserName}"/>
                    
-                    <DataGridTextColumn Header="PurchasesCount" Binding="{Binding PurchasesCount}"/>
-                    <DataGridTextColumn Header="TotalPurchasePrice" Binding="{Binding TotalPurchasePrice}"/>
+                    <DataGridTextColumn Header="Nombre d'Assets achetés" Binding="{Binding PurchasesCount}"/>
+                    <DataGridTextColumn Header="Prix total de l'achat" Binding="{Binding TotalPurchasePrice}"/>
 
 
                 </DataGrid.Columns>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderViewControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderViewControl.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Fantastic3D.GUI.SectionControls"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              x:Name="root"
@@ -16,18 +17,30 @@
         </WrapPanel>
         <WrapPanel >
             <GroupBox Margin="20" Height="160" Width="300" HorizontalAlignment="Left" Header="Détails"  >
-                <StackPanel  >
+                <StackPanel>
+                    <StackPanel.Resources>
+                        <system:Double x:Key="IconSize">16</system:Double>
+                    </StackPanel.Resources>
                     <WrapPanel>
                         <Label   Margin="5" Content="Date D'achat: "  />
-                        <TextBox x:Name="Date" Width="150"  Text="{Binding Date}" />
+                        <TextBlock x:Name="Date" Width="150"  Text="{Binding Date, StringFormat=d}" />
                     </WrapPanel>
                     <WrapPanel>
                         <Label   Margin="5" Content="Acheteur:"  />
-                        <TextBox x:Name="PurchasingUserName" Width="150"  Text="{Binding PurchasingUserName}" />
+                        <TextBlock x:Name="PurchasingUserName" Width="150"  Text="{Binding PurchasingUserName}" />
+                        <Button Margin="10, 0, 0, 0"  Tag="{Binding PurchasingUserId}" Click="ViewUserButton_Click"
+                                              Style="{StaticResource MaterialDesignFloatingActionMiniSecondaryLightButton}"
+                                              ToolTip="Voir l'utilisateur qui a fait la commande"
+                                              IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" Cursor="Hand">
+                            <materialDesign:PackIcon
+                                                Kind="UserDetails"
+                                                Height="{StaticResource IconSize}"
+                                                Width="{StaticResource IconSize}"/>
+                        </Button>
                     </WrapPanel>
                     <WrapPanel>
                         <Label   Margin="5" Content="Total: "  />
-                        <TextBox x:Name="TotalPurchasePrice" Width="150"  Text="{Binding TotalPurchasePrice}" />
+                        <TextBlock x:Name="TotalPurchasePrice" Width="150"  Text="{Binding TotalPurchasePrice}" />
                     </WrapPanel>
                 </StackPanel>
             </GroupBox>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderViewControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/OrderViewControl.xaml.cs
@@ -54,5 +54,13 @@ namespace Fantastic3D.GUI.SectionControls
         {
             ((MainWindow)Application.Current.MainWindow).Navigator.NavigateTo(typeof(OrderListControl));
         }
+        private void ViewUserButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (((Button)sender).Tag != null && ((Button)sender).Tag is int userId)
+            {
+                ((MainWindow)Application.Current.MainWindow)
+                    .Navigator.NavigateTo(typeof(UserViewControl), userId);
+            }
+        }
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ReviewControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ReviewControl.xaml
@@ -5,12 +5,16 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Fantastic3D.GUI.SectionControls"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              Loaded="Window_Loaded"
              d:DesignHeight="450" d:DesignWidth="800">
 
     <StackPanel Background="{DynamicResource MaterialDesignBackground}">
         <StackPanel>
+            <StackPanel.Resources>
+                <system:Double x:Key="IconSize">16</system:Double>
+            </StackPanel.Resources>
             <TextBlock DockPanel.Dock="Top" FontSize="30"  HorizontalAlignment="Center">Gestion des avis</TextBlock>
             <WrapPanel HorizontalAlignment="Center">
                 <Label Content="Filtres" />
@@ -19,21 +23,59 @@
             <DataGrid x:Name="ReviewDataGrid" Margin="10" Height="265" SelectedItem="{Binding CurrentReview}" ItemsSource="{Binding Reviews}" AutoGenerateColumns="False"   IsReadOnly="True"   >
                 <DataGrid.Columns >
                     <DataGridTextColumn Header="Id" Binding="{Binding Id}" />
-                    <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" />
-                    <DataGridTextColumn Header="AssetId" Binding="{Binding AssetId}" />
-                    <DataGridTextColumn Header="AuthorId" Binding="{Binding AuthorId}" />
-                    <DataGridTextColumn Header="AuthorName" Binding="{Binding AuthorName}" />
-                    
-                    <DataGridTemplateColumn  Header="Note">
+
+                    <DataGridTemplateColumn Header="Modèle 3D">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <materialDesign:RatingBar
-                                      x:Name="BasicRatingBar" Value="{Binding Note}">
-                                </materialDesign:RatingBar>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding AssetName}" VerticalAlignment="Center"  TextWrapping="WrapWithOverflow" Width="50"/>
+                                    <Button Margin="10, 0, 0, 0" Tag="{Binding AssetId}" Click="ViewAssetButton_Click"
+                                      Style="{StaticResource MaterialDesignFloatingActionMiniSecondaryLightButton}"
+                                      ToolTip="Voir les détails du modèle 3D"
+                                      IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}">
+                                        <materialDesign:PackIcon
+                                        Kind="FileEye"
+                                        Height="{StaticResource IconSize}"
+                                        Width="{StaticResource IconSize}" />
+                                    </Button>
+                                </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn  Header="IsPublished">
+
+                    <DataGridTemplateColumn Header="Commentaire">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock TextWrapping="WrapWithOverflow" Width="150" Text="{Binding Comment}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+
+                    <DataGridTemplateColumn Header="Auteur et note">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Vertical">
+                                    <materialDesign:RatingBar
+                                      x:Name="BasicRatingBar" Value="{Binding Note}">
+                                    </materialDesign:RatingBar>
+                                    <StackPanel Orientation="Horizontal" Margin="0, 15">
+                                        <TextBlock Text="{Binding AuthorName}" VerticalAlignment="Center"  TextWrapping="WrapWithOverflow" Width="80"/>
+                                        <Button Margin="10, 0, 0, 0"  Tag="{Binding AuthorId}" Click="ViewUserButton_Click"
+                                              Style="{StaticResource MaterialDesignFloatingActionMiniSecondaryLightButton}"
+                                              ToolTip="Voir l'auteur de l'avis"
+                                              IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}">
+                                                <materialDesign:PackIcon
+                                                Kind="UserDetails"
+                                                Height="{StaticResource IconSize}"
+                                                Width="{StaticResource IconSize}"/>
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn  Header="Avis publié ?">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ToggleButton
@@ -46,14 +88,14 @@
                     <DataGridTemplateColumn  Header="Supprimer">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <!--<Image Height="24" Source="/SectionControls/Icone_trash.png" Cursor="IBeam"/>-->
-                                <Button Height="24" Click="DeleteReview"  >
-                                    <Button.Template>
-                                        <ControlTemplate>
-                                            <materialDesign:PackIcon Kind="TrashCanOutline" />
-                                            <!--<Image Source="/SectionControls/Icone_trash.png"/>-->
-                                        </ControlTemplate>
-                                    </Button.Template>
+                                <Button Click="DeleteReview" 
+                                      Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
+                                      ToolTip="Supprimer l'avis"
+                                      IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}">
+                                    <materialDesign:PackIcon
+                                        Kind="Trash"
+                                        Height="{StaticResource IconSize}"
+                                        Width="{StaticResource IconSize}"/>
                                 </Button>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ReviewControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/ReviewControl.xaml.cs
@@ -75,5 +75,23 @@ namespace Fantastic3D.GUI.SectionControls
                 MessageBox.Show(ex.Message, "Source de données non accessible", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
+
+        private void ViewUserButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (((Button)sender).Tag != null && ((Button)sender).Tag is int userId)
+            {
+                ((MainWindow)Application.Current.MainWindow)
+                    .Navigator.NavigateTo(typeof(UserViewControl), userId);
+            }
+        }
+
+        private void ViewAssetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (((Button)sender).Tag != null && ((Button)sender).Tag is int assetId)
+            {
+                ((MainWindow)Application.Current.MainWindow)
+                    .Navigator.NavigateTo(typeof(ModelViewerControl), assetId);
+            }
+        }
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml
@@ -18,8 +18,8 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Psedo" Binding="{Binding Username}"/>
                 <DataGridTextColumn Header="Email" Binding="{Binding Email}"/>
-                <DataGridTextColumn Header="Nom" Binding="{Binding FirstName}"/>
-                <DataGridTextColumn Header="Prénom" Binding="{Binding LastName}"/>
+                <DataGridTextColumn Header="Prénom" Binding="{Binding FirstName}"/>
+                <DataGridTextColumn Header="Nom" Binding="{Binding LastName}"/>
                 <DataGridTextColumn Header="Role" Binding="{Binding Role}"/>
             </DataGrid.Columns>
         </DataGrid>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserListControl.xaml.cs
@@ -30,8 +30,7 @@ namespace Fantastic3D.GUI.SectionControls
 
         private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            ((MainWindow)Application.Current.MainWindow).Navigator.NavigateTo(typeof(UserViewControl));
-            ((UserViewControl)((MainWindow)Application.Current.MainWindow).Navigator.CurrentViewControl.Content).EditableUser = UsersList.CurrentUser;
+            ((MainWindow)Application.Current.MainWindow).Navigator.NavigateTo(typeof(UserViewControl), UsersList.CurrentUser);
         }
         // Get All Users and bind them into the listbox
         private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml
@@ -7,8 +7,7 @@
              xmlns:converters="clr-namespace:Fantastic3D.GUI.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
-             x:Name="root"
-             Loaded="View_Loaded">
+             x:Name="root">
     <UserControl.Resources>
         <converters:UserRolesComboBoxConverter x:Key="UserRolesComboBoxConverter"/>
     </UserControl.Resources>

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml.cs
@@ -22,11 +22,11 @@ namespace Fantastic3D.GUI.SectionControls
     /// <summary>
     /// Logique d'interaction pour UserViewControl.xaml
     /// </summary>
-    public partial class UserViewControl : UserControl
+    public partial class UserViewControl : UserControl, IContentLoadableById
     {
         public List<User> UserToValidate { get; set; } = new();
         public IDataManager<User, UserDto> _dataSource = ((App)Application.Current).Services.GetService<IDataManager<User, UserDto>>();
-        
+
 
         private static readonly DependencyProperty CurrentUserProperty =
             DependencyProperty.Register(nameof(EditableUser), typeof(User), typeof(UserViewControl));
@@ -40,9 +40,24 @@ namespace Fantastic3D.GUI.SectionControls
                 if (editableUser != value)
                 {
                     SetValue(CurrentUserProperty, value);
+                    OnContentUpdated();
                 }
             }
         }
+
+        public async void LoadContentById(int id)
+        {
+            try
+            { 
+                EditableUser = await _dataSource.GetAsync(id);
+            }
+            catch (DataRetrieveException ex)
+            {
+                MessageBox.Show(ex.Message, "Utilisateur non trouvé", MessageBoxButton.OK, MessageBoxImage.Error);
+                EditableUser = new User();
+            }
+        }
+
         public UserViewControl()
         {
             InitializeComponent();
@@ -104,11 +119,12 @@ namespace Fantastic3D.GUI.SectionControls
 
         }
 
-        private void View_Loaded(object sender, RoutedEventArgs e)
+        private void OnContentUpdated()
         {
             ValidationButton.Content = (EditableUser.Id == 0) ? "Ajouter" : "Sauvegarder";
             DeletionButton.Visibility = (EditableUser.Id == 0) ? Visibility.Hidden : Visibility.Visible;
         }
+
     }
 }
 

--- a/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/SectionControls/UserViewControl.xaml.cs
@@ -22,7 +22,7 @@ namespace Fantastic3D.GUI.SectionControls
     /// <summary>
     /// Logique d'interaction pour UserViewControl.xaml
     /// </summary>
-    public partial class UserViewControl : UserControl, IContentLoadableById
+    public partial class UserViewControl : UserControl, IContentLoadableById, IContentLoadableWithModel
     {
         public List<User> UserToValidate { get; set; } = new();
         public IDataManager<User, UserDto> _dataSource = ((App)Application.Current).Services.GetService<IDataManager<User, UserDto>>();
@@ -125,6 +125,13 @@ namespace Fantastic3D.GUI.SectionControls
             DeletionButton.Visibility = (EditableUser.Id == 0) ? Visibility.Hidden : Visibility.Visible;
         }
 
+        public void LoadContentWithModel(IManageable modelInstance)
+        {
+            if (modelInstance is User user)
+                EditableUser = user;
+            else
+                throw new NavigationException("Expected " + typeof(User).Name + " type. Type sent was: " + modelInstance.GetType().Name);
+        }
     }
 }
 

--- a/Fantastic3D/Fantastic3D.WPFApp/Utilities/INavigator.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/Utilities/INavigator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Fantastic3D.DataManager;
+using Fantastic3D.GUI.SectionControls;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,6 +17,8 @@ namespace Fantastic3D.GUI.Utilities
         void RegisterViews(ICollection<Control> views);
 
         void NavigateTo(Type type);
+        void NavigateTo(Type viewWithContent, int id);
+        void NavigateTo(Type viewWithContent, IManageable modelInstance);
 
     }
 }

--- a/Fantastic3D/Fantastic3D.WPFApp/Utilities/NavigationException.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/Utilities/NavigationException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Fantastic3D.GUI.Utilities
+{
+    [Serializable]
+    public class NavigationException : Exception
+    {
+        public override string Message => "Couldn't navigate through view as expected.";
+        public NavigationException()
+        {
+        }
+
+        public NavigationException(string? message) : base(message)
+        {
+        }
+
+        public NavigationException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected NavigationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Fantastic3D/Fantastic3D.WPFApp/Utilities/Navigator.cs
+++ b/Fantastic3D/Fantastic3D.WPFApp/Utilities/Navigator.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using Fantastic3D.AppModels;
+using Fantastic3D.DataManager;
+using Fantastic3D.GUI.SectionControls;
 
 namespace Fantastic3D.GUI.Utilities
 {
@@ -50,6 +52,32 @@ namespace Fantastic3D.GUI.Utilities
                 return false;
             CurrentViewControl.Content = _previousViews.Pop();
                 return true;
+        }
+
+        public void NavigateTo(Type viewWithContent, int id)
+        {
+            NavigateTo(viewWithContent);
+            if(CurrentViewControl.Content is IContentLoadableById newView)
+            {
+                newView.LoadContentById(id);
+            }
+            else
+            {
+                throw new NavigationException();
+            }
+        }
+
+        public void NavigateTo(Type viewWithContent, IManageable modelInstance)
+        {
+            NavigateTo(viewWithContent);
+            if (CurrentViewControl.Content is IContentLoadableWithModel newView)
+            {
+                newView.LoadContentWithModel(modelInstance);
+            }
+            else
+            {
+                throw new NavigationException();
+            }
         }
     }
 }


### PR DESCRIPTION
Cette branche ajoute une logique de Navigation améliorée :
Au lieu de Naviguer sur une vue puis de passer un objet, on peut maintenant utiliser : 
- NavigateTo( Vue, Objet ) pour afficher la vue avec l'objet chargé
- NavigateTo( Vue, Id ) pour afficher la vue avec l'objet correspondant à l'Id chargé dans cette vue

Quelques ajouts en plus dans les templates de vue existants pour utiliser cette logique.